### PR TITLE
[DEPLOY] Nginx 연동, SSL인증서 발급, HTTPS 적용

### DIFF
--- a/docker compose.prod.yml
+++ b/docker compose.prod.yml
@@ -1,0 +1,70 @@
+# 배포용 docker compose.prod.yml 파일
+# 실행 방법: docker-compose -f docker-compose.prod.yml up -d --build
+
+services:
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"    
+    volumes:
+      - './app:/code/app'
+    depends_on:
+      - teamC_mysql
+    env_file: 
+      - .env
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GOOGLE_VISION_API_KEY=${GOOGLE_VISION_API_KEY}
+      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
+
+  teamC_mysql:
+    image: mysql:latest  
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      Lang: C.UTF-8
+    ports:
+      - "3307:3306"  
+    volumes:
+      - ./db_data:/var/lib/mysql
+
+  teamC_redis:
+    image: redis:latest
+    ports: 
+      - "6380:6379"
+    volumes: 
+      - /var/lib/docker/volumes/redis/_data
+      - /app/redis.conf
+    command: redis-server /app/redis.conf
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"           # HTTP
+      - "443:443"         # HTTPS (SSL 인증서 사용 시)
+    restart: always
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro 
+      - ./certbot/conf:/etc/letsencrypt 
+      - ./certbot/www:/var/www/certbot
+      # - ./certs:/etc/nginx/certs:ro           
+      # - ./static:/usr/share/nginx/html:ro   
+    depends_on:
+      - backend
+      # - frontend
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+  
+  certbot: 
+    image: certbot/certbot
+    restart: unless-stopped
+    container_name: certbot
+    volumes: 
+      - ./certbot/conf:/etc/letsencrypt  
+      - ./certbot/www:/var/www/certbot
+    depends_on:
+      - nginx
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,81 @@
+# init-letsencrypt.sh
+# docker-compose.prod.yml과 같은 위치에 있을것.
+#!/bin/bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+compose_file="docker-compose.prod.yml"
+
+domains=(myinsideout.world www.myinsideout.world) # 등록한 도메인으로
+rsa_key_size=4096
+data_path="./certbot"   # 인증서 데이터 저장 경로
+email="winterteamc7@gmail.com" # Let's Encrypt에서 사용할 본인 이메일로
+staging=0 # 1: 테스트 서버(한도 있음), 0: 실제 서버
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose -f "$compose_file" run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+echo "### Starting nginx ..."
+docker-compose -f "$compose_file" up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose -f "$compose_file" run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose -f "$compose_file" run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose -f "$compose_file" exec nginx nginx -s reload

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,41 @@
+# nginx/nginx.conf
+    server {
+        listen 80;
+        server_name myinsideout.world www.myinsideout.world;
+        charset utf-8;
+
+        # SSL 인증서 발급을 자동화하는 Certbot을 사용하기 위한 설정
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+            allow all;
+        }
+
+        # Http로 들어온 요청을 Https로 Redirect
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name myinsideout.world www.myinsideout.world;
+        server_tokens off;
+
+        # SSL 인증서 경로
+        ssl_certificate /etc/letsencrypt/live/myinsideout.world/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/myinsideout.world/privkey.pem;
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        # 백엔드 API 프록시
+        location /api/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #68 

## 📝 작업 내용

- 배포용 docker compose.prod.yml 파일 생성
- SSL 인증서 발급용 init-letsencrypt.sh 파일 생성
- nginx/nginx.conf 파일 생성
- DNS : myinsideout.world ,  www.myinsideout.world  도메인 구매 및 등록
- [인스턴스에서 pull 이후 재확인 예정] MySQL Workbench 외부 접속 완료

## 체크리스트
- [ o] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3723bcf0-051d-46e1-9e50-d7363bb93ceb)


## 💬 리뷰 요구사항(선택)
