### PR TITLE
[Fix] 상황설명만으로 실행 찐구현

### DIFF
--- a/app/crud/preparation.py
+++ b/app/crud/preparation.py
@@ -18,14 +18,17 @@ if not os.path.exists(UPLOAD_DIR):
 
 user_counters = {}
 
-async def file(db: Session, user_id: int, category: str, files: Optional[List[UploadFile]] = File([]), content: str = Form(...)):
+async def file(db: Session, user_id: int, category: str, files: Optional[List[UploadFile]] = File(None), content: str = Form(...)):
     file_details = []
     global user_counters
 
     if user_id not in user_counters:
         user_counters[user_id] = 1  
 
-    image = None
+    if files is None:
+        files = []
+    
+    image = "No file uploaded"
 
     if files:  # 파일이 제공된 경우만 처리
         for file in files:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#92 

## 📝 작업 내용
- 처음 이미지를 안 넣고 상황설명만 넣었을때 7개 감정이 나오지 않는 문제를 해결
- 처음부터 상황설명을 넣었을때 7개 감정이 제대로 나오는것을 확인
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
close #92 
